### PR TITLE
[refactor] 유저컨트롤러, 카카오/네이버 서비스 로직 정리

### DIFF
--- a/makeat_be/src/main/java/io/makeat/makeat_be/controller/UserController.java
+++ b/makeat_be/src/main/java/io/makeat/makeat_be/controller/UserController.java
@@ -60,18 +60,16 @@ public class UserController {
 
     @GetMapping("/kakao")
     public ResponseEntity getKakaoCI(@RequestParam String code, Model model) throws IOException{
-        String[] tokens = ks.getToken(code);
-        String access_token = tokens[0];
-        String refresh_token = tokens[1];
-        Map<String, Object> userInfo = ks.getUserInfo(access_token);
-        //model.addAttribute("code", code);
-        model.addAttribute("access_token", access_token);
-        model.addAttribute("refresh_token", refresh_token);
-        model.addAttribute("userInfo", userInfo);
+        
+        //인증코드로 토큰, 유저정보 GET
+        String token = ks.getToken(code);
+        Map<String, Object> userInfo = ks.getUserInfo(token);
 
+        System.out.println("jun");
         // jwt를 생성하는 로직
         String jwt = loginService.login("kakao", (String) userInfo.get("loginId"));
 
+        System.out.println("hu");
 
         //ci는 비즈니스 전환후 검수신청 -> 허락받아야 수집 가능
 
@@ -101,38 +99,13 @@ public class UserController {
 
     @GetMapping("/naver")
     public ResponseEntity getNaverCI(@RequestParam String code, Model model) throws IOException, ParseException {
-        //인증코드로 토큰 받아오는 코드
-        //액세스, 리프레쉬 코드 model에 저장
 
-        String[] tokens = ns.getToken(code);
-        String access_token = tokens[0];
-        String refresh_token = tokens[1];
-
-        //여기까지가 액세스, 리프레쉬토큰값 받아오기
-
-        String header = "Bearer " + access_token; // Bearer 다음에 공백 추가
-        String apiURL = "https://openapi.naver.com/v1/nid/me";
-
-        Map<String, String> requestHeaders = new HashMap<>();
-        requestHeaders.put("Authorization", header);
-        model.addAttribute("access_token", access_token);
-        model.addAttribute("refresh_token", refresh_token);
-
-        //사용자정보 json ns.getApi(apiURL,requestHeaders)
-        JSONParser jsonParser = new JSONParser();
-        JSONObject jsonObj = (JSONObject) jsonParser.parse(ns.getApi(apiURL,requestHeaders));
-        JSONObject response = (JSONObject) jsonObj.get("response");
-
-        String id = response.get("id").toString();
-        String name = response.get("name").toString();
-        String gender = response.get("gender").toString();
-
-        model.addAttribute("id, id");
-        model.addAttribute("name", name);
-        model.addAttribute("gender", gender);
-
+        //인증코드로 토큰, 유저정보 GET
+        String token = ns.getToken(code);
+        Map<String, Object> userInfo = ns.getUserInfo(token);
 
         // jwt를 생성하는 로직
+        String id = (String) userInfo.get("id");
         String jwt = loginService.login("naver", id);
 
         // ci는 비즈니스 전환후 검수신청 -> 허락받아야 수집 가능

--- a/makeat_be/src/main/java/io/makeat/makeat_be/controller/UserController.java
+++ b/makeat_be/src/main/java/io/makeat/makeat_be/controller/UserController.java
@@ -60,16 +60,13 @@ public class UserController {
 
     @GetMapping("/kakao")
     public ResponseEntity getKakaoCI(@RequestParam String code, Model model) throws IOException{
-        
+
         //인증코드로 토큰, 유저정보 GET
         String token = ks.getToken(code);
         Map<String, Object> userInfo = ks.getUserInfo(token);
 
-        System.out.println("jun");
         // jwt를 생성하는 로직
         String jwt = loginService.login("kakao", (String) userInfo.get("loginId"));
-
-        System.out.println("hu");
 
         //ci는 비즈니스 전환후 검수신청 -> 허락받아야 수집 가능
 

--- a/makeat_be/src/main/java/io/makeat/makeat_be/service/KakaoLoginService.java
+++ b/makeat_be/src/main/java/io/makeat/makeat_be/service/KakaoLoginService.java
@@ -1,6 +1,7 @@
 package io.makeat.makeat_be.service;
 
 import io.makeat.makeat_be.repository.UserRepository;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
+@Slf4j
 @Service
 public class KakaoLoginService {
 
@@ -51,7 +53,7 @@ public class KakaoLoginService {
             bw.flush();
 
             int responseCode = urlConnection.getResponseCode();
-            System.out.println("responseCode = " + responseCode);
+            log.info("responseCode = " + responseCode);
 
 
             BufferedReader br = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
@@ -60,14 +62,14 @@ public class KakaoLoginService {
             while ((line = br.readLine()) != null) {
                 result += line;
             }
-            System.out.println("result = " + result);
+            log.info("result = " + result);
 
             // json parsing
             JSONParser parser = new JSONParser();
             JSONObject elem = (JSONObject) parser.parse(result);
 
             token = elem.get("access_token").toString();
-            System.out.println("access_token = " + token);
+            log.info("access_token = " + token);
             br.close();
             bw.close();
         } catch (IOException e) {
@@ -94,7 +96,7 @@ public class KakaoLoginService {
             urlConnection.setRequestMethod("GET");
 
             int responseCode = urlConnection.getResponseCode();
-            System.out.println("responseCode = " + responseCode);
+            log.info("responseCode = " + responseCode);
 
             BufferedReader br = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
             String line = "";
@@ -104,7 +106,7 @@ public class KakaoLoginService {
                 res+=line;
             }
 
-            System.out.println("res = " + res);
+            log.info("res = " + res);
 
             JSONParser parser = new JSONParser();
             JSONObject obj = (JSONObject) parser.parse(res);

--- a/makeat_be/src/main/java/io/makeat/makeat_be/service/NaverLoginService.java
+++ b/makeat_be/src/main/java/io/makeat/makeat_be/service/NaverLoginService.java
@@ -1,6 +1,7 @@
 package io.makeat.makeat_be.service;
 
 // 네이버 API 예제 - 회원프로필 조회
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +16,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
-
+@Slf4j
 @Service
 public class NaverLoginService {
 
@@ -52,7 +53,7 @@ public class NaverLoginService {
             bw.flush();
 
             int responseCode = urlConnection.getResponseCode();
-            System.out.println("responseCode = " + responseCode);
+            log.info("responseCode = " + responseCode);
 
             BufferedReader br = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
             String line = "";
@@ -60,14 +61,14 @@ public class NaverLoginService {
             while ((line = br.readLine()) != null) {
                 result += line;
             }
-            System.out.println("result = " + result);
+            log.info("result = " + result);
 
             // json parsing
             JSONParser parser = new JSONParser();
             JSONObject elem = (JSONObject) parser.parse(result);
 
             token = elem.get("token").toString();
-            System.out.println("access_token = " + token);
+            log.info("access_token = " + token);
 
             br.close();
             bw.close();

--- a/makeat_be/src/main/java/io/makeat/makeat_be/service/NaverLoginService.java
+++ b/makeat_be/src/main/java/io/makeat/makeat_be/service/NaverLoginService.java
@@ -1,11 +1,12 @@
 package io.makeat.makeat_be.service;
 
 // 네이버 API 예제 - 회원프로필 조회
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 
 import java.io.*;
 import java.net.HttpURLConnection;
@@ -26,16 +27,16 @@ public class NaverLoginService {
 
 
     /**
-     * json 응답 파싱해서 액세스,리프레쉬 토큰 반환
+     * 인가코드로 토큰 반환
      * @param code
-     * @return String[] tokens
+     * @return
+     * @throws IOException
      */
-    public String[] getToken(String code) throws IOException {
+    public String getToken(String code) throws IOException {
 
-        // 인가코드로 토큰받기
         String host = "https://nid.naver.com/oauth2.0/token";
         URL url = new URL(host);
-        String[] tokens = {"", ""};
+        String token = "";
         HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
         try {
             urlConnection.setRequestMethod("POST");
@@ -65,12 +66,8 @@ public class NaverLoginService {
             JSONParser parser = new JSONParser();
             JSONObject elem = (JSONObject) parser.parse(result);
 
-            String access_token = elem.get("access_token").toString();
-            String refresh_token = elem.get("refresh_token").toString();
-            tokens[0] = access_token;
-            tokens[1] = refresh_token;
-            System.out.println("refresh_token = " + refresh_token);
-            System.out.println("access_token = " + access_token);
+            token = elem.get("token").toString();
+            System.out.println("access_token = " + token);
 
             br.close();
             bw.close();
@@ -79,10 +76,48 @@ public class NaverLoginService {
         } catch (ParseException e) {
             e.printStackTrace();
         }
-        return tokens;
+        return token;
     }
 
+    /**
+     * 토큰으로 유저정보 파싱해서 반환
+     * @param token
+     * @return
+     * @throws ParseException
+     */
+    public Map<String, Object> getUserInfo(String token) throws ParseException {
+
+        Map<String, Object> result = new HashMap<>();
+
+        String header = "Bearer " + token; // Bearer 다음에 공백 추가
+        String apiURL = "https://openapi.naver.com/v1/nid/me";
+
+        Map<String, String> requestHeaders = new HashMap<>();
+        requestHeaders.put("Authorization", header);
+
+        JSONParser jsonParser = new JSONParser();
+        JSONObject jsonObj = (JSONObject) jsonParser.parse(getApi(apiURL,requestHeaders));
+        JSONObject response = (JSONObject) jsonObj.get("response");
+
+        String id = response.get("id").toString();
+        String name = response.get("name").toString();
+        String gender = response.get("gender").toString();
+
+        result.put("id", id);
+        result.put("nickname", name);
+        result.put("gender", gender);
+
+        return result;
+    }
+
+    /**
+     * Api 접근해서 Body정보 반환
+     * @param apiUrl
+     * @param requestHeaders
+     * @return
+     */
     public static String getApi(String apiUrl, Map<String, String> requestHeaders){
+
         HttpURLConnection con = connect(apiUrl);
         try {
             con.setRequestMethod("GET");
@@ -103,6 +138,11 @@ public class NaverLoginService {
         }
     }
 
+    /**
+     * API 연결
+     * @param apiUrl
+     * @return
+     */
     private static HttpURLConnection connect(String apiUrl){
         try {
             URL url = new URL(apiUrl);
@@ -114,27 +154,27 @@ public class NaverLoginService {
         }
     }
 
-
+    /**
+     * body 정보 반환
+     * @param body
+     * @return
+     */
     private static String readBody(InputStream body){
         InputStreamReader streamReader = new InputStreamReader(body);
 
-
         try (BufferedReader lineReader = new BufferedReader(streamReader)) {
             StringBuilder responseBody = new StringBuilder();
-
 
             String line;
             while ((line = lineReader.readLine()) != null) {
                 responseBody.append(line);
             }
 
-
             return responseBody.toString();
         } catch (IOException e) {
             throw new RuntimeException("API 응답을 읽는데 실패했습니다.", e);
         }
     }
-
 }
 
 


### PR DESCRIPTION
1. 카카오, 네이버 서비스 getToken(), getUserInfo() 공통 매서드로 정리
2. 유저컨트롤러에서 서비스 코드 제거
3. 유저컨트롤러에서 jwt 이전에 getToken(), getUserInfo()만 남기고 정리